### PR TITLE
fix: Add pinentry-qt to the default ignore list

### DIFF
--- a/src/config/bismuth_config.kcfg
+++ b/src/config/bismuth_config.kcfg
@@ -55,7 +55,7 @@
 
     <entry name="ignoreClass" type="String">
       <label>Ignore windows with certain classes(comma-separated list)</label>
-      <default>yakuake,spectacle,Conky,zoom</default>
+      <default>yakuake,spectacle,Conky,zoom,pinentry-qt</default>
     </entry>
 
     <entry name="ignoreRole" type="String">


### PR DESCRIPTION
The pinentry-qt password prompt is inherently a popup and is not expected to be tiled or to change the current tiling arrangement.

Related: #394

<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Summary of the pull request.

## Breaking Changes

Do your changes intentionally break something on the user side or configuration?

## UI Changes

| Before                         | After                         |
| ------------------------------ | ----------------------------- |
| Screenshot of UI before change | Screenshot of UI after change |

## Test Plan

1. Reload Script...
2. ...
3. Something happens

## Related Issues

Closes #X
