### PR TITLE
fix: Use optional chaining operator in windowId.toString to avoid err…

### DIFF
--- a/src/kwinscript/driver/window.ts
+++ b/src/kwinscript/driver/window.ts
@@ -292,7 +292,7 @@ export class DriverWindowImpl implements DriverWindow {
 
   public toString(): string {
     // Using a shorthand name to keep debug message tidy
-    return `KWin(${this.client.windowId.toString(16)}.${
+    return `KWin(${this.client.windowId?.toString(16)}.${
       this.client.resourceClass
     })`;
   }


### PR DESCRIPTION
…ors when windowId is undefined in Wayland

<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Summary of the pull request.

## Breaking Changes

Do your changes intentionally break something on the user side or configuration?

## UI Changes

| Before                         | After                         |
| ------------------------------ | ----------------------------- |
| Screenshot of UI before change | Screenshot of UI after change |

## Test Plan

1. Reload Script...
2. ...
3. Something happens

## Related Issues

Closes #X
